### PR TITLE
[feat] import and export custom characters

### DIFF
--- a/src/utils/ChatUtils.ts
+++ b/src/utils/ChatUtils.ts
@@ -78,6 +78,11 @@ export function deserialize_chat(text: string, characters: Map<string, Character
 export async function deserialize_custom_chars(text: string, ds: CustomDataSource): Promise<CustomCharacter[]> {
   const obj = JSON.parse(text);
   const chars = await ds.get_characters();
+  // ensure that json without "custom_chars" field can also be imported
+  if (obj.custom_chars == undefined) {
+    return [];
+  }
+
   const customChars = (obj.custom_chars as any[]).map(ch => {
       const char = new CustomCharacter(ds, ch.name, ch.img)
       char.id = ch.char_id;

--- a/src/utils/ChatUtils.ts
+++ b/src/utils/ChatUtils.ts
@@ -6,24 +6,7 @@ import ChatItem from "../model/ChatItem";
 import { ArknightsChatItemProps } from "../model/props/ArknightsProps";
 import { YuzutalkChatItemProps } from "../model/props/YuzutalkProps";
 
-export function serialize_chat(chat: ChatItem[], activeChars: ChatChar[]): string {
-  return JSON.stringify({
-    chat: chat.map(ch => ({
-      char_id: ch.char?.character.id,
-      img: ch.char?.img,
-      is_breaking: ch.is_breaking,
-      content: ch.content,
-      yuzutalk: ch.yuzutalk,
-      arknights: ch.arknights,
-    })),
-    chars: activeChars.map(ch => ({
-      char_id: ch.character.id,
-      img: ch.img,
-    })),
-  }, undefined, 2);
-}
-
-export async function serialize_chat_with_custom_chars(chat: ChatItem[], activeChars: ChatChar[], customChars: Character[]): Promise<string> {
+export function serialize_chat(chat: ChatItem[], activeChars: ChatChar[], customChars: Character[] = []): string {
   return JSON.stringify({
     chat: chat.map(ch => ({
       char_id: ch.char?.character.id,
@@ -38,12 +21,12 @@ export async function serialize_chat_with_custom_chars(chat: ChatItem[], activeC
       img: ch.img,
     })),
     custom_chars: customChars.map((ch) => {
-      let c = ch as CustomCharacter
+      let c = ch as CustomCharacter;
       return {
         char_id: c.id,
         img: c.image,
         name: c.names.get("zh-cn"),
-      }
+      };
     }),
   }, undefined, 2);
 }
@@ -84,17 +67,17 @@ export async function deserialize_custom_chars(text: string, ds: CustomDataSourc
   }
 
   const customChars = (obj.custom_chars as any[]).map(ch => {
-      const char = new CustomCharacter(ds, ch.name, ch.img)
+      const char = new CustomCharacter(ds, ch.name, ch.img);
       char.id = ch.char_id;
-      chars.map((c) => {
+      chars.forEach((c) => {
         if (c.id == ch.char_id) {
           ds.remove_character(c as CustomCharacter);
         }
-      })
+      });
       ds.add_character(char);
       return char;
     }
-  )
+  );
   return customChars;
 }
 

--- a/src/utils/ChatUtils.ts
+++ b/src/utils/ChatUtils.ts
@@ -75,12 +75,18 @@ export function deserialize_chat(text: string, characters: Map<string, Character
   return [chat, chars];
 }
 
-export function deserialize_custom_chars(text: string, ds: CustomDataSource): CustomCharacter[] {
+export async function deserialize_custom_chars(text: string, ds: CustomDataSource): Promise<CustomCharacter[]> {
   const obj = JSON.parse(text);
+  const chars = await ds.get_characters();
   const customChars = (obj.custom_chars as any[]).map(ch => {
-      let char = new CustomCharacter(ds, ch.name, ch.img)
-      char.id = ch.char_id
-      ds.add_character(char)
+      const char = new CustomCharacter(ds, ch.name, ch.img)
+      char.id = ch.char_id;
+      chars.map((c) => {
+        if (c.id == ch.char_id) {
+          ds.remove_character(c as CustomCharacter);
+        }
+      })
+      ds.add_character(char);
       return char;
     }
   )

--- a/src/view/ChatView.tsx
+++ b/src/view/ChatView.tsx
@@ -102,10 +102,17 @@ export default function ChatView() {
         const text = await read_file_as_text(file);
 
         const ds = DataSources[DataSources.length - 1] as CustomDataSource;
-        const customChars = deserialize_custom_chars(text, ds)
-        customChars.map((char)=>{
-          ctx.characters.set(char.id, char);
+        const customChars = await deserialize_custom_chars(text, ds)
+        const chars = new Map(ctx.characters)
+        customChars.map((char) => {
+          const ch = chars.get(char.id);
+          if (ch != null) {
+            chars.delete(char.id)
+          }
+          chars.set(char.id, char);
         })
+        ctx.characters = chars;
+        ctx.setCharacters(chars);
 
         const [newChat, newChars] = deserialize_chat(text, ctx.characters);
 

--- a/src/view/ChatView.tsx
+++ b/src/view/ChatView.tsx
@@ -5,13 +5,15 @@ import { useAppContext } from "../model/AppContext";
 import ChatItem from "../model/ChatItem";
 import { ClearChatEventName, LoadCodeEventName, SaveCodeEventName } from "../model/Events";
 import { editChatDialog, renderChat } from "../renderer/RendererFactory";
-import { deserialize_chat, serialize_chat } from "../utils/ChatUtils";
+import { deserialize_chat, deserialize_custom_chars, serialize_chat, serialize_chat_with_custom_chars } from "../utils/ChatUtils";
 import { get_now_filename } from "../utils/DateUtils";
 import { download_text } from "../utils/DownloadUtils";
 import { prompt_file, read_file_as_text } from "../utils/FileUtils";
 import { get_key_string } from "../utils/KeyboardUtils";
 import CharList from "./CharList";
 import ChatInputView from "./ChatInputView";
+import { DataSources } from "../model/Constants";
+import CustomDataSource from "../data/CustomDataSource";
 
 export default function ChatView() {
   const ctx = useAppContext();
@@ -75,8 +77,11 @@ export default function ChatView() {
 
   // save JSON
   useEffect(() => {
-    const handler = () => {
-      download_text(serialize_chat(chat, ctx.activeChars), `closure-talk-${get_now_filename()}.json`);
+    const handler = async () => {
+      const ds = DataSources[DataSources.length - 1] as CustomDataSource;
+      const customChars = await ds.get_characters();
+      const serializedStr = await serialize_chat_with_custom_chars(chat, ctx.activeChars, customChars);
+      download_text(serializedStr, `closure-talk-${get_now_filename()}.json`);
     };
 
     window.addEventListener(SaveCodeEventName, handler);
@@ -95,6 +100,13 @@ export default function ChatView() {
 
       try {
         const text = await read_file_as_text(file);
+
+        const ds = DataSources[DataSources.length - 1] as CustomDataSource;
+        const customChars = deserialize_custom_chars(text, ds)
+        customChars.map((char)=>{
+          ctx.characters.set(char.id, char);
+        })
+
         const [newChat, newChars] = deserialize_chat(text, ctx.characters);
 
         setChat(newChat);


### PR DESCRIPTION
Finished the import and export function of custom characters data along with the chat json file
See #19 
When importing data, if there is a character in the json file that has the same id as the one in the browser's localstorage, the current strategy is to overwrite the browser character's data with the data in the json file
I deployed a demo on GitHub Pages: https://halozhy.github.io/closure-talk/

实现了自定义角色数据随聊天 json 文件一并的导入导出功能
参见 #19 
导入数据的时候，如果 json 文件里存在和浏览器 localstorage 中 id 一致的角色，目前的策略是用 json 文件中的数据覆盖浏览器中此角色的数据
我把 demo 部署在了 GitHub Pages 上面: https://halozhy.github.io/closure-talk/